### PR TITLE
Support for paths with spaces

### DIFF
--- a/lib/jspm-worker-orchestrator.js
+++ b/lib/jspm-worker-orchestrator.js
@@ -28,7 +28,7 @@ class JspmWorkerOrchestrator {
 
         }
 
-        this._child = exec(`node ${path.join(__dirname, 'jspm-worker.js')} ${this._workerId}`);
+        this._child = exec(`node "${path.join(__dirname, 'jspm-worker.js')}" ${this._workerId}`);
 
         this._child.stderr.on('data', error => {
 


### PR DESCRIPTION
# Summary

This PR fixes an issue preventing jspm-watch from working in a path that contains spaces. It adds quotes around a path in a shell call to `node`.
# Defect

Using jspm-watch in a directory with spaces in the full path fails
## To Reproduce
1. Create a new jspm project in a directory such as `/Users/mplewis/My Projects/some-jspm-project/`
2. Install `jspm-watch`
3. Run the example from the docs:

``` js
var JspmWatch = require('jspm-watch')

var watcher = new JspmWatch({
  app: {
    input: 'src/rachio.js',
    output: 'dist/rachio.js'
  }
})

watcher.start()
```
## Expected

``` sh
$ node watch.js
[15:00:15] JSPM Watch: Building entire app...
[15:00:16] JSPM Watch: App build finished successfully in 0.69 s.
```
## Actual

```
/Users/mplewis/My Projects/some-jspm-project/node_modules/jspm-watch/lib/jspm-worker-orchestrator.js:36
            throw new Error(error);
            ^

Error: module.js:457
    throw err;
    ^

Error: Cannot find module '/Users/mplewis/My'
    at Function.Module._resolveFilename (module.js:455:15)
    at Function.Module._load (module.js:403:25)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3

    at Socket._child.stderr.on.error (/Users/mplewis/My Projects/some-jspm-project/node_modules/jspm-watch/lib/jspm-worker-orchestrator.js:36:19)
    at emitOne (events.js:101:20)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at Pipe.onread (net.js:543:20)
```
