### PR TITLE
Added usePolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ Same as `app.buildOptions`.
 #### batchDelay
 Delay in milliseconds before build will be fired. Default is `250`.
 
+#### debug
+
+Turns on debug output. Useful when trying to understand problems. Default is `false`.
 
 ### start([options])
 Returns instance of JSPM Watch for chaining.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ Same as `app.buildOptions`.
 #### batchDelay
 Delay in milliseconds before build will be fired. Default is `250`.
 
+#### usePolling
+
+Turns on [chokidar polling](https://github.com/paulmillr/chokidar#performance) option. Try to use it
+if you are having trouble with fs events. Default is `false`.
+
 #### debug
 
 Turns on debug output. Useful when trying to understand problems. Default is `false`.

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ class Watcher {
         this._globby = this._globby || globby;
         this._fs = this._fs || fs;
         this._isDebugEnabled = options.debug;
+        this._usePolling = options.usePolling;
         this._jspmConf = this._getJspmPackageJson();
 
         this._conf = {
@@ -592,6 +593,7 @@ class Watcher {
         this._watcher = chokidar.watch(this._watchExpression, {
                 ignoreInitial: true,
                 persistent: true,
+                usePolling: this._usePolling,
                 ignored: (filepath) => {
 
                     return _.includes(this._watchIgnored, this._path.resolve(filepath));


### PR DESCRIPTION
I get unlink events on windows 10 when i save a file with Intellij. Its unclear why i get the wrong event but polling solves this for me.

It would be great you could merge and do a new release so i can stop using my patched version of *jspm-watch*.